### PR TITLE
Fix links to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ http://fuckingfrogs.fr:8080/?source=huge.jpg&width=300&height=300
 [![Build Status](https://travis-ci.org/pierrre/imageserver.png?branch=master)](https://travis-ci.org/pierrre/imageserver)
 
 ## Examples
-- [Simple](https://github.com/pierrre/imageserver/blob/master/_examples/simple/simple.go)
-- [Advanced](https://github.com/pierrre/imageserver/blob/master/_examples/advanced/advanced.go)
+- [Simple](https://github.com/pierrre/imageserver/blob/master/examples/simple/simple.go)
+- [Advanced](https://github.com/pierrre/imageserver/blob/master/examples/advanced/advanced.go)
 
 ## Documentation
 - http://godoc.org/github.com/pierrre/imageserver


### PR DESCRIPTION
The link to the examples in the README has an extra `_` begore the root directory name.