### PR TITLE
add more params and functionalities taking advantage of GraphicsMagick

### DIFF
--- a/graphicsmagick/graphicsmagick.go
+++ b/graphicsmagick/graphicsmagick.go
@@ -58,8 +58,6 @@ const (
 //
 // - grey: "-colorspace" param with "GRAY"
 //
-// - no_strip: "-strip" param
-//
 // - trim: "-trim" param
 //
 // - no_interlace: "-interlace" param with "Line"
@@ -140,11 +138,6 @@ func (server *Server) process(im *imageserver.Image, params imageserver.Params) 
 	}
 
 	err = server.buildArgumentsGrey(arguments, params)
-	if err != nil {
-		return nil, err
-	}
-
-	err = server.buildArgumentsStrip(arguments, params)
 	if err != nil {
 		return nil, err
 	}
@@ -474,14 +467,6 @@ func (server *Server) buildArgumentsGrey(arguments *list.List, params imageserve
 	if grey {
 		arguments.PushBack("-colorspace")
 		arguments.PushBack("GRAY")
-	}
-	return nil
-}
-
-func (server *Server) buildArgumentsStrip(arguments *list.List, params imageserver.Params) error {
-	strip, _ := params.GetBool("no_strip")
-	if !strip {
-		arguments.PushBack("-strip")
 	}
 	return nil
 }

--- a/graphicsmagick/graphicsmagick.go
+++ b/graphicsmagick/graphicsmagick.go
@@ -67,7 +67,6 @@ const (
 // - flip: "-flip" param
 //
 // - flop: "-flop" param
-
 type Server struct {
 	Server         imageserver.Server
 	Executable     string        // path to "gm" executable, usually "/usr/bin/gm"

--- a/graphicsmagick/graphicsmagick_test.go
+++ b/graphicsmagick/graphicsmagick_test.go
@@ -408,38 +408,6 @@ func TestBuildArgumentsGrey(t *testing.T) {
 	}
 }
 
-func TestBuildArgumentsStrip(t *testing.T) {
-	testSamples := []testSample{
-		testSample{
-			Params: imageserver.Params{
-				"no_strip": true,
-			},
-			ExpectedArguments: "",
-		},
-		testSample{
-			Params: imageserver.Params{
-				"no_strip": false,
-			},
-			ExpectedArguments: "-strip ",
-		},
-	}
-	server := &Server{
-		Server:     &imageserver.StaticServer{Image: testdata.Medium},
-		Executable: "gm",
-	}
-	for _, ts := range testSamples {
-		arguments := list.New()
-		err := server.buildArgumentsStrip(arguments, ts.Params)
-		if err != nil {
-			t.Errorf(err.Error())
-		}
-		args := convertArgumentsToString(arguments)
-		if args != ts.ExpectedArguments {
-			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
-		}
-	}
-}
-
 func TestBuildArgumentsTrim(t *testing.T) {
 	testSamples := []testSample{
 		testSample{

--- a/graphicsmagick/graphicsmagick_test.go
+++ b/graphicsmagick/graphicsmagick_test.go
@@ -1,6 +1,8 @@
 package graphicsmagick
 
 import (
+	"container/list"
+	"strconv"
 	"testing"
 	"time"
 
@@ -45,5 +47,554 @@ func TestGetErrorTimeout(t *testing.T) {
 	}
 	if _, ok := err.(*imageserver.ImageError); !ok {
 		t.Fatalf("unexpected error type: %T", err)
+	}
+}
+
+type testSample struct {
+	Params            imageserver.Params
+	ExpectedArguments string
+}
+
+func convertArgumentsToString(list *list.List) string {
+	var str string
+	for e := list.Front(); e != nil; e = e.Next() {
+		substr, ok := e.Value.(string)
+		if ok {
+			str += substr + " "
+		} else {
+			return ""
+		}
+	}
+	return str
+}
+
+func TestBuildArgumentsResize(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"width":  100,
+				"height": 150,
+			},
+			ExpectedArguments: "-resize 100x150 ",
+		},
+
+		testSample{
+			Params: imageserver.Params{
+				"width":  200,
+				"height": 120,
+				"fill":   true,
+			},
+			ExpectedArguments: "-resize 200x120^ ",
+		},
+
+		testSample{
+			Params: imageserver.Params{
+				"width":        120,
+				"height":       100,
+				"ignore_ratio": true,
+			},
+			ExpectedArguments: "-resize 120x100! ",
+		},
+
+		testSample{
+			Params: imageserver.Params{
+				"width":              120,
+				"height":             100,
+				"only_shrink_larger": true,
+			},
+			ExpectedArguments: "-resize 120x100> ",
+		},
+
+		testSample{
+			Params: imageserver.Params{
+				"width":                120,
+				"height":               100,
+				"only_enlarge_smaller": true,
+			},
+			ExpectedArguments: "-resize 120x100< ",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		_, _, err := server.buildArgumentsResize(arguments, ts.Params)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+
+}
+
+func TestBuildArgumentsBackground(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"background": "59ecaf",
+			},
+			ExpectedArguments: "-background #59ecaf ",
+		},
+
+		testSample{
+			Params: imageserver.Params{
+				"background": "0059ecaf",
+			},
+			ExpectedArguments: "-background #0059ecaf ",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		err := server.buildArgumentsBackground(arguments, ts.Params)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+
+}
+func TestBuildArgumentsExtent(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"width":  100,
+				"height": 150,
+				"extent": true,
+			},
+			ExpectedArguments: "-resize 100x150 -extent 100x150 ",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		width, height, err := server.buildArgumentsResize(arguments, ts.Params)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		err = server.buildArgumentsExtent(arguments, ts.Params, width, height)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+
+}
+
+func TestBuildArgumentsQuality(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"quality": 70,
+				"format":  "jpeg",
+			},
+			ExpectedArguments: "-quality 70 ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"quality": 120,
+				"format":  "png",
+			},
+			ExpectedArguments: "-quality 120 ",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		format, err := ts.Params.GetString("format")
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		err = server.buildArgumentsQuality(arguments, ts.Params, format)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+
+}
+
+func TestBuildArgumentsGravity(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"gravity": "n",
+			},
+			ExpectedArguments: "-gravity North ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"gravity": "s",
+			},
+			ExpectedArguments: "-gravity South ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"gravity": "e",
+			},
+			ExpectedArguments: "-gravity East ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"gravity": "w",
+			},
+			ExpectedArguments: "-gravity West ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"gravity": "ne",
+			},
+			ExpectedArguments: "-gravity NorthEast ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"gravity": "nw",
+			},
+			ExpectedArguments: "-gravity NorthWest ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"gravity": "se",
+			},
+			ExpectedArguments: "-gravity SouthEast ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"gravity": "sw",
+			},
+			ExpectedArguments: "-gravity SouthWest ",
+		},
+		testSample{
+			Params:            imageserver.Params{},
+			ExpectedArguments: "-gravity Center ",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		err := server.buildArgumentsGravity(arguments, ts.Params)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+
+}
+
+func TestBuildArgumentsCrop(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"crop": "100,150",
+			},
+			ExpectedArguments: "-crop 100x150 +repage ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"crop": "120,130,40,50",
+			},
+			ExpectedArguments: "-crop 120x130+40+50 +repage ",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		err := server.buildArgumentsCrop(arguments, ts.Params)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+}
+
+func TestBuildArgumentsRotate(t *testing.T) {
+	ts := testSample{
+		Params: imageserver.Params{
+			"rotate": 90,
+		},
+		ExpectedArguments: "-rotate 90 ",
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	arguments := list.New()
+	err := server.buildArgumentsRotate(arguments, ts.Params)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	args := convertArgumentsToString(arguments)
+	if args != ts.ExpectedArguments {
+		t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+	}
+}
+
+func TestBuildArgumentsMonochrome(t *testing.T) {
+	ts := testSample{
+		Params: imageserver.Params{
+			"monochrome": true,
+		},
+		ExpectedArguments: "-monochrome ",
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	arguments := list.New()
+	err := server.buildArgumentsMonochrome(arguments, ts.Params)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	args := convertArgumentsToString(arguments)
+	if args != ts.ExpectedArguments {
+		t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+	}
+}
+
+func TestBuildArgumentsGrey(t *testing.T) {
+	ts := testSample{
+		Params: imageserver.Params{
+			"grey": true,
+		},
+		ExpectedArguments: "-colorspace GRAY ",
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	arguments := list.New()
+	err := server.buildArgumentsGrey(arguments, ts.Params)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	args := convertArgumentsToString(arguments)
+	if args != ts.ExpectedArguments {
+		t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+	}
+}
+
+func TestBuildArgumentsStrip(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"no_strip": true,
+			},
+			ExpectedArguments: "",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"no_strip": false,
+			},
+			ExpectedArguments: "-strip ",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		err := server.buildArgumentsStrip(arguments, ts.Params)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+}
+
+func TestBuildArgumentsTrim(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"trim": true,
+			},
+			ExpectedArguments: "-trim ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"trim": false,
+			},
+			ExpectedArguments: "",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		err := server.buildArgumentsTrim(arguments, ts.Params)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+}
+
+func TestBuildArgumentsInterlace(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"no_interlace": true,
+			},
+			ExpectedArguments: "",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"no_interlace": false,
+			},
+			ExpectedArguments: "-interlace Line ",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		err := server.buildArgumentsInterlace(arguments, ts.Params)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+}
+
+func TestBuildArgumentsFlip(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"flip": true,
+			},
+			ExpectedArguments: "-flip ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"flip": false,
+			},
+			ExpectedArguments: "",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		err := server.buildArgumentsFlip(arguments, ts.Params)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+}
+
+func TestBuildArgumentsFlop(t *testing.T) {
+	testSamples := []testSample{
+		testSample{
+			Params: imageserver.Params{
+				"flop": true,
+			},
+			ExpectedArguments: "-flop ",
+		},
+		testSample{
+			Params: imageserver.Params{
+				"flop": false,
+			},
+			ExpectedArguments: "",
+		},
+	}
+	server := &Server{
+		Server:     &imageserver.StaticServer{Image: testdata.Medium},
+		Executable: "gm",
+	}
+	for _, ts := range testSamples {
+		arguments := list.New()
+		err := server.buildArgumentsFlop(arguments, ts.Params)
+		if err != nil {
+			t.Errorf(err.Error())
+		}
+		args := convertArgumentsToString(arguments)
+		if args != ts.ExpectedArguments {
+			t.Errorf("Failed to build arguments for gm.\nGot:  " + args + "\nWant: " + ts.ExpectedArguments)
+		}
+	}
+}
+
+func TestConvertArgumentsToString(t *testing.T) {
+	arguments := list.New()
+	arguments.PushBack("a0")
+	arguments.PushBack("a1")
+	arguments.PushBack("a2")
+	arguments.PushBack("a3")
+
+	argumentsString := convertArgumentsToString(arguments)
+
+	if argumentsString != "a0 a1 a2 a3 " {
+		t.Errorf("Failed to convert arguments to string")
+	}
+}
+
+func TestConvertArgumentsToSlice(t *testing.T) {
+	arguments := list.New()
+	arguments.PushBack("a0")
+	arguments.PushBack("a1")
+	arguments.PushBack("a2")
+	arguments.PushBack("a3")
+
+	argumentSlice := convertArgumentsToSlice(arguments)
+
+	for i, e := range argumentSlice {
+		if e != "a"+strconv.Itoa(i) {
+			t.Errorf("Failed to convert arguments to slice")
+			break
+		}
 	}
 }

--- a/http/graphicsmagick/graphicsmagick.go
+++ b/http/graphicsmagick/graphicsmagick.go
@@ -35,31 +35,51 @@ func (parser *Parser) Parse(req *http.Request, params imageserver.Params) error 
 }
 
 func (parser *Parser) parse(req *http.Request, params imageserver.Params) error {
-	if err := imageserver_http.ParseQueryInt("width", req, params); err != nil {
-		return err
+	// parse bool params
+	boolParams := []string{
+		"ignore_ratio",
+		"fill",
+		"only_shrink_larger",
+		"only_enlarge_smaller",
+		"extent",
+		"monochrome",
+		"grey",
+		"no_strip",
+		"trim",
+		"no_interlace",
+		"flip",
+		"flop",
 	}
-	if err := imageserver_http.ParseQueryInt("height", req, params); err != nil {
-		return err
+	for _, bp := range boolParams {
+		err := imageserver_http.ParseQueryBool(bp, req, params)
+		if err != nil {
+			return err
+		}
 	}
-	if err := imageserver_http.ParseQueryBool("fill", req, params); err != nil {
-		return err
+
+	// parse integer params
+	intParams := []string{
+		"w",
+		"h",
+		"rotate",
+		"q",
 	}
-	if err := imageserver_http.ParseQueryBool("ignore_ratio", req, params); err != nil {
-		return err
+	for _, ip := range intParams {
+		err := imageserver_http.ParseQueryInt(ip, req, params)
+		if err != nil {
+			return err
+		}
 	}
-	if err := imageserver_http.ParseQueryBool("only_shrink_larger", req, params); err != nil {
-		return err
+
+	// parse string params
+	stringParams := []string{
+		"bg",
+		"gravity",
+		"crop",
+		"format",
 	}
-	if err := imageserver_http.ParseQueryBool("only_enlarge_smaller", req, params); err != nil {
-		return err
-	}
-	imageserver_http.ParseQueryString("background", req, params)
-	if err := imageserver_http.ParseQueryBool("extent", req, params); err != nil {
-		return err
-	}
-	imageserver_http.ParseQueryString("format", req, params)
-	if err := imageserver_http.ParseQueryInt("quality", req, params); err != nil {
-		return err
+	for _, sp := range stringParams {
+		imageserver_http.ParseQueryString(sp, req, params)
 	}
 	return nil
 }

--- a/http/graphicsmagick/graphicsmagick_test.go
+++ b/http/graphicsmagick/graphicsmagick_test.go
@@ -20,27 +20,15 @@ func TestParse(t *testing.T) {
 	for _, tc := range []TC{
 		{},
 		{
-			query: url.Values{"width": {"100"}},
+			query: url.Values{"ignore_ratio": {"true"}},
 			expectedParams: imageserver.Params{globalParam: imageserver.Params{
-				"width": 100,
-			}},
-		},
-		{
-			query: url.Values{"height": {"100"}},
-			expectedParams: imageserver.Params{globalParam: imageserver.Params{
-				"height": 100,
+				"ignore_ratio": true,
 			}},
 		},
 		{
 			query: url.Values{"fill": {"true"}},
 			expectedParams: imageserver.Params{globalParam: imageserver.Params{
 				"fill": true,
-			}},
-		},
-		{
-			query: url.Values{"ignore_ratio": {"true"}},
-			expectedParams: imageserver.Params{globalParam: imageserver.Params{
-				"ignore_ratio": true,
 			}},
 		},
 		{
@@ -56,17 +44,98 @@ func TestParse(t *testing.T) {
 			}},
 		},
 		{
-			query: url.Values{"background": {"123abc"}},
-			expectedParams: imageserver.Params{globalParam: imageserver.Params{
-				"background": "123abc",
-			}},
-		},
-		{
 			query: url.Values{"extent": {"true"}},
 			expectedParams: imageserver.Params{globalParam: imageserver.Params{
 				"extent": true,
 			}},
 		},
+
+		{
+			query: url.Values{"monochrome": {"true"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"monochrome": true,
+			}},
+		},
+		{
+			query: url.Values{"grey": {"true"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"grey": true,
+			}},
+		},
+
+		{
+			query: url.Values{"no_strip": {"true"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"no_strip": true,
+			}},
+		},
+		{
+			query: url.Values{"trim": {"true"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"trim": true,
+			}},
+		},
+		{
+			query: url.Values{"no_interlace": {"true"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"no_interlace": true,
+			}},
+		},
+		{
+			query: url.Values{"flip": {"true"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"flip": true,
+			}},
+		},
+		{
+			query: url.Values{"flop": {"true"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"flop": true,
+			}},
+		},
+		{
+			query: url.Values{"w": {"100"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"w": 100,
+			}},
+		},
+		{
+			query: url.Values{"h": {"100"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"h": 100,
+			}},
+		},
+		{
+			query: url.Values{"rotate": {"90"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"rotate": 90,
+			}},
+		},
+		{
+			query: url.Values{"q": {"75"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"q": 75,
+			}},
+		},
+		{
+			query: url.Values{"bg": {"fafafa"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"bg": "fafafa",
+			}},
+		},
+		{
+			query: url.Values{"gravity": {"se"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"gravity": "se",
+			}},
+		},
+		{
+			query: url.Values{"crop": {"200,200,0,0"}},
+			expectedParams: imageserver.Params{globalParam: imageserver.Params{
+				"crop": "200,200,0,0",
+			}},
+		},
+
 		{
 			query: url.Values{"format": {"jpeg"}},
 			expectedParams: imageserver.Params{globalParam: imageserver.Params{
@@ -74,26 +143,13 @@ func TestParse(t *testing.T) {
 			}},
 		},
 		{
-			query: url.Values{"quality": {"75"}},
-			expectedParams: imageserver.Params{globalParam: imageserver.Params{
-				"quality": 75,
-			}},
+			query:              url.Values{"ignore_ratio": {"invalid"}},
+			expectedParamError: globalParam + ".ignore_ratio",
 		},
-		{
-			query:              url.Values{"width": {"invalid"}},
-			expectedParamError: globalParam + ".width",
-		},
-		{
-			query:              url.Values{"height": {"invalid"}},
-			expectedParamError: globalParam + ".height",
-		},
+
 		{
 			query:              url.Values{"fill": {"invalid"}},
 			expectedParamError: globalParam + ".fill",
-		},
-		{
-			query:              url.Values{"ignore_ratio": {"invalid"}},
-			expectedParamError: globalParam + ".ignore_ratio",
 		},
 		{
 			query:              url.Values{"only_shrink_larger": {"invalid"}},
@@ -108,8 +164,54 @@ func TestParse(t *testing.T) {
 			expectedParamError: globalParam + ".extent",
 		},
 		{
-			query:              url.Values{"quality": {"invalid"}},
-			expectedParamError: globalParam + ".quality",
+			query:              url.Values{"monochrome": {"invalid"}},
+			expectedParamError: globalParam + ".monochrome",
+		},
+		{
+			query:              url.Values{"grey": {"invalid"}},
+			expectedParamError: globalParam + ".grey",
+		},
+		{
+			query:              url.Values{"no_strip": {"invalid"}},
+			expectedParamError: globalParam + ".no_strip",
+		},
+		{
+			query:              url.Values{"trim": {"invalid"}},
+			expectedParamError: globalParam + ".trim",
+		},
+		{
+			query:              url.Values{"no_interlace": {"invalid"}},
+			expectedParamError: globalParam + ".no_interlace",
+		},
+		{
+			query:              url.Values{"flip": {"invalid"}},
+			expectedParamError: globalParam + ".flip",
+		},
+		{
+			query:              url.Values{"flop": {"invalid"}},
+			expectedParamError: globalParam + ".flop",
+		},
+
+		{
+			query:              url.Values{"w": {"invalid"}},
+			expectedParamError: globalParam + ".w",
+		},
+		{
+			query:              url.Values{"h": {"invalid"}},
+			expectedParamError: globalParam + ".h",
+		},
+		{
+			query:              url.Values{"rotate": {"invalid"}},
+			expectedParamError: globalParam + ".rotate",
+		},
+		{
+			query:              url.Values{"density": {"invalid"}},
+			expectedParamError: globalParam + ".density",
+		},
+
+		{
+			query:              url.Values{"q": {"invalid"}},
+			expectedParamError: globalParam + ".q",
 		},
 	} {
 		func() {


### PR DESCRIPTION
The added params are:
* gravity: "-gravity" param, default is Center
* crop: "-crop" param with "+repage"
* rotate: "-rotate" param
* monochrome: "-monochrome" param
* grey: "-colorspace" param with "GRAY"
* no_strip: "-strip" param
* trim: "-trim" param
* no_interlace: "-interlace" param with "Line". Useful for JPEG, I'm not sure about other formats.
* flip: "-flip" param
* flop: "-flop" param
Please go to GraphicsMagick documentation for detailed explanation.

Added test functions for buildArguments.

Params parser now divided into 3 main parts to parse int, bool and string type params. Adding params is easier this way.