### PR TITLE
Add disk based cache system

### DIFF
--- a/cache/file/benchmark_test.go
+++ b/cache/file/benchmark_test.go
@@ -1,0 +1,26 @@
+package file
+
+import (
+	"testing"
+
+	"github.com/pierrre/imageserver"
+	cachetest "github.com/pierrre/imageserver/cache/_test"
+	"github.com/pierrre/imageserver/testdata"
+)
+
+func BenchmarkGet(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		im   *imageserver.Image
+	}{
+		{"Small", testdata.Small},
+		{"Medium", testdata.Medium},
+		{"Large", testdata.Large},
+		{"Huge", testdata.Huge},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			cch := newTestCache(b)
+			cachetest.BenchmarkGet(b, cch, 1, tc.im)
+		})
+	}
+}

--- a/cache/file/file.go
+++ b/cache/file/file.go
@@ -1,0 +1,64 @@
+// Package file provides a disk based cache.
+package file
+
+import (
+	"fmt"
+	"github.com/pierrre/imageserver"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Cache is a implementation of disk based cache system.
+type Cache struct {
+	Path string
+	mu   sync.RWMutex
+}
+
+// Get implements imageserver/cache.Cache.
+func (cache *Cache) Get(key string, params imageserver.Params) (*imageserver.Image, error) {
+	if cache.Path == "" {
+		return nil, fmt.Errorf("file cache path is not")
+	}
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+	data, err := cache.getData(key)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, nil
+	}
+	im := new(imageserver.Image)
+	if err := im.UnmarshalBinaryNoCopy(data); err != nil {
+		return nil, err
+	}
+	return im, nil
+}
+
+func (cache *Cache) getData(key string) ([]byte, error) {
+	item, err := ioutil.ReadFile(filepath.Join(cache.Path, key))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+// Set implements imageserver/cache.Cache.
+func (cache *Cache) Set(key string, im *imageserver.Image, params imageserver.Params) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	data, err := im.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	return cache.setData(key, data)
+}
+
+func (cache *Cache) setData(key string, data []byte) error {
+	return ioutil.WriteFile(filepath.Join(cache.Path, key), data, 0644)
+}

--- a/cache/file/file_test.go
+++ b/cache/file/file_test.go
@@ -1,0 +1,107 @@
+package file
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pierrre/imageserver"
+	imageserver_cache "github.com/pierrre/imageserver/cache"
+	cachetest "github.com/pierrre/imageserver/cache/_test"
+	"github.com/pierrre/imageserver/testdata"
+	"io/ioutil"
+	"os"
+)
+
+var _ imageserver_cache.Cache = &Cache{}
+var testDirPath string
+
+func TestMain(m *testing.M) {
+	os.Exit(realMain(m))
+}
+
+func realMain(m *testing.M) int {
+	path, err := ioutil.TempDir("", "filecache")
+	if err != nil {
+		return 1
+	}
+	testDirPath = path
+	defer func() {
+		_ = os.RemoveAll(testDirPath)
+	}()
+	return m.Run()
+}
+
+func TestGetSet(t *testing.T) {
+	cache := newTestCache(t)
+	cachetest.TestGetSet(t, cache)
+}
+
+func TestGetMiss(t *testing.T) {
+	cache := newTestCache(t)
+	cachetest.TestGetMiss(t, cache)
+}
+
+func TestPathIsNotSet(t *testing.T) {
+	cache := &Cache{Path: ""}
+	_, err := cache.Get(cachetest.KeyValid, imageserver.Params{})
+	if err == nil {
+		t.Fatal("no error")
+	}
+}
+
+func TestFileExistsButCantRead(t *testing.T) {
+	cache := newTestCache(t)
+	if err := os.Chmod(filepath.Join(testDirPath, cachetest.KeyValid), 0111); err != nil {
+		t.Fatal("os.Chmod return error.")
+	}
+	defer func() {
+		err := os.Chmod(filepath.Join(testDirPath, cachetest.KeyValid), 0644)
+		if err != nil {
+			t.Fatal("os.Chmod return error.")
+		}
+	}()
+	_, err := cache.Get(cachetest.KeyValid, imageserver.Params{})
+	if err == nil {
+		t.Fatal("no error")
+	}
+}
+
+func TestGetErrorUnmarshal(t *testing.T) {
+	cache := newTestCache(t)
+	data, err := testdata.Medium.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = data[:len(data)-1]
+	err = cache.setData(cachetest.KeyValid, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cache.Get(cachetest.KeyValid, imageserver.Params{})
+	if err == nil {
+		t.Fatal("no error")
+	}
+	if _, ok := err.(*imageserver.ImageError); !ok {
+		t.Fatalf("unexpected error type: %T", err)
+	}
+}
+
+func TestSetErrorMarshal(t *testing.T) {
+	cache := newTestCache(t)
+	im := &imageserver.Image{
+		Format: strings.Repeat("a", imageserver.ImageFormatMaxLen+1),
+	}
+	err := cache.Set(cachetest.KeyValid, im, imageserver.Params{})
+	if err == nil {
+		t.Fatal("no error")
+	}
+	if _, ok := err.(*imageserver.ImageError); !ok {
+		t.Fatalf("unexpected error type: %T", err)
+	}
+}
+
+func newTestCache(tb testing.TB) *Cache {
+	cache := &Cache{Path: testDirPath}
+	return cache
+}


### PR DESCRIPTION
I added the package "cache/file" that support a disk based cache system.
With low memory environment the disk based cache system is useful.

Usage (part of examples/cache):

```
var flagFile     = "/tmp"

// part of examples/cache/cache.go
func newServerFile(srv imageserver.Server) imageserver.Server {
	if flagFile == "" {
		return srv
	}
	cch := imageserver_cache_file.Cache{flagFile }
	kg := imageserver_cache.NewParamsHashKeyGenerator(sha256.New)
	return &imageserver_cache.Server{
		Server:       srv,
		Cache:        &cch,
		KeyGenerator: kg,
	}
}
```

